### PR TITLE
fix: フレーム時刻の実測ODR(208Hz)対応と、FIFO停止時の回収フェーズ・欠損可視化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+### Changes
+
+---
+
+- **FEAT**: INSOLEのFIFO受信停止時に**回収フェーズ（drain / catch-up）**を追加。`setSensorConfig`でfifoから他モードへ切り替える際、停止時点でFWが生成済みのシリアルを固定ターゲットとして、未要求分（catch-up）と要求済み未受信分（carry-over）を回収してから新しい設定を適用します。従来は`stop()`が再要求キューを即座に破棄し、未要求のバックログも回収しなかったため、**欠損通知ゼロのまま収録末尾が数秒欠ける**ことがありました（2台同時収録の実測で、遅れた側が要求スパンの86〜89%しか記録されない例を確認。JS SDK [ORPHE-INSOLE.js#62](https://github.com/Orphe-OSS/ORPHE-INSOLE.js/pull/62) と同じ問題）。回収の上限時間は`OrpheFifoConfig.drainTimeoutMillis`（既定3000ms、`0`で従来どおり即時切替）。取りこぼしが無い正常系では1往復で完了します。回収できなかったシリアルは`sensorValueIsNotFound`で通知されます
+- **FIX**: FIFO受信の停止時（切断・`close`を含む）、要求済みで未受信のシリアルを`sensorValueIsNotFound`で通知してから破棄するようにしました。従来は無通知で破棄され、アプリから欠損に気づけませんでした（CORE `Orphe`のFIFO経路も同様）
+- **BREAKING**: INSOLEのパケット内フレーム時刻を、名目200Hz（5ms/frame）ではなく実測ODR **208Hz**（LSM6DSOXの標準ODR、約4.808ms/frame）で合成するようにしました。`OrpheInsoleValue`の`startTime`のパケット内間隔が約4%短くなります（200Hz経路: 5ms→約4.808ms、100Hz経路: 10ms→約9.615ms）。従来はパケット内だけが約4%引き伸ばされ、パケット境界で連続サンプルの時刻差が0や負になりえたため、サンプル毎のdtで角速度等を積分する処理が系統的にずれていました（JS SDK v1.3.1 の`IMU_ODR_HZ`と同じ根拠・同じ値）
+
 ## 2026-07-28 (2)
 
 ### Changes

--- a/orphecoresdk/src/main/java/io/orphe/orphecoresdk/Orphe.java
+++ b/orphecoresdk/src/main/java/io/orphe/orphecoresdk/Orphe.java
@@ -712,6 +712,12 @@ public class Orphe {
                     public void onMissing(int serialNumber) {
                         mOrpheCallback.sensorValueIsNotFound(serialNumber);
                     }
+
+                    @Override
+                    public void onDrainCompleted(int recoveredCount, int unrecoveredCount) {
+                        // CORE側は回収フェーズ（drain）を使用しない。
+                        // stop()時の未回収分は onMissing 経由で通知される。
+                    }
                 }
         );
     }

--- a/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheFifoConfig.java
+++ b/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheFifoConfig.java
@@ -4,6 +4,9 @@ package io.orphe.orphecoresdk;
  * fifo受信方式のリクエスト設定。
  */
 public class OrpheFifoConfig {
+    /** {@link #drainTimeoutMillis}の既定値。 */
+    public static final long DEFAULT_DRAIN_TIMEOUT_MILLIS = 3000L;
+
     public static final OrpheFifoConfig DEFAULT =
             new OrpheFifoConfig(200, 200L, 5000L, 100, 1500);
 
@@ -24,6 +27,7 @@ public class OrpheFifoConfig {
                 requestTimeoutMillis,
                 legacyCarryOverLimit(maxRetryCount),
                 1500,
+                DEFAULT_DRAIN_TIMEOUT_MILLIS,
                 maxRetryCount
         );
     }
@@ -41,6 +45,30 @@ public class OrpheFifoConfig {
                 requestTimeoutMillis,
                 maxCarryOverSerials,
                 ringBufferCapacity,
+                DEFAULT_DRAIN_TIMEOUT_MILLIS,
+                0
+        );
+    }
+
+    /**
+     * @param drainTimeoutMillis FIFO停止時の回収フェーズ（drain/catch-up）の上限時間[ms]。
+     *                           0で無効（従来どおり即時停止。取り残しは missing として通知される）。
+     */
+    public OrpheFifoConfig(
+            final int requestLength,
+            final long requestIntervalMillis,
+            final long requestTimeoutMillis,
+            final int maxCarryOverSerials,
+            final int ringBufferCapacity,
+            final long drainTimeoutMillis
+    ) {
+        this(
+                requestLength,
+                requestIntervalMillis,
+                requestTimeoutMillis,
+                maxCarryOverSerials,
+                ringBufferCapacity,
+                drainTimeoutMillis,
                 0
         );
     }
@@ -51,6 +79,7 @@ public class OrpheFifoConfig {
             final long requestTimeoutMillis,
             final int maxCarryOverSerials,
             final int ringBufferCapacity,
+            final long drainTimeoutMillis,
             final int legacyMaxRetryCount
     ) {
         if (requestLength < 1 || requestLength > 200) {
@@ -71,11 +100,15 @@ public class OrpheFifoConfig {
             throw new IllegalArgumentException(
                     "ringBufferCapacity must be between 1 and 65535.");
         }
+        if (drainTimeoutMillis < 0L) {
+            throw new IllegalArgumentException("drainTimeoutMillis must not be negative.");
+        }
         this.requestLength = requestLength;
         this.requestIntervalMillis = requestIntervalMillis;
         this.requestTimeoutMillis = requestTimeoutMillis;
         this.maxCarryOverSerials = maxCarryOverSerials;
         this.ringBufferCapacity = ringBufferCapacity;
+        this.drainTimeoutMillis = drainTimeoutMillis;
         this.maxRetryCount = legacyMaxRetryCount;
     }
 
@@ -99,6 +132,15 @@ public class OrpheFifoConfig {
 
     /** FWリングバッファから安全に取得できる最大シリアル数。 */
     public final int ringBufferCapacity;
+
+    /**
+     * FIFO停止時の回収フェーズ（drain/catch-up）の上限時間[ms]。
+     *
+     * <p>停止時点でFWが既に生成済みのシリアルを固定ターゲットとして、未要求分（catch-up）と
+     * 要求済み未受信分（carry-over）の回収を続ける。0で無効（従来どおり即時停止）。
+     * 取りこぼしが無い正常系では1往復で完了するため、実質的な遅延はほぼ無い。
+     */
+    public final long drainTimeoutMillis;
 
     private static int legacyCarryOverLimit(final int maxRetryCount) {
         if (maxRetryCount < 0) {

--- a/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheFifoRequester.java
+++ b/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheFifoRequester.java
@@ -25,8 +25,17 @@ final class OrpheFifoRequester<T> {
 
         void onValue(@NonNull T value);
 
-        /** FWがnoDataを返し、回復不能と確定したシリアルを通知する。 */
+        /** FWがnoDataを返した、または停止時に回収できず、回復不能と確定したシリアルを通知する。 */
         void onMissing(int serialNumber);
+
+        /**
+         * {@link #beginDrain(long)}で開始した回収フェーズが完了したことを通知する。
+         * 呼び出し時点で要求器は停止済み。
+         *
+         * @param recoveredCount   回収フェーズ中に受信できた値の数
+         * @param unrecoveredCount 回収できず missing として通知した数
+         */
+        void onDrainCompleted(int recoveredCount, int unrecoveredCount);
     }
 
     private final long serialIntervalMillis;
@@ -37,6 +46,15 @@ final class OrpheFifoRequester<T> {
     private boolean running;
     private Integer lastSerialNumber;
     private ActiveRequest activeRequest;
+
+    /** 回収フェーズ（drain/catch-up）中かどうか。runningと併存する。 */
+    private boolean draining;
+    /** 回収フェーズの締切[ms]。 */
+    private long drainDeadlineMillis;
+    /** 停止時点のFW最新シリアル（固定ターゲット）。最初のcurrentState応答で確定する。 */
+    private Integer drainTargetSerial;
+    /** 回収フェーズ中に受信できた値の数。 */
+    private int drainRecoveredCount;
 
     OrpheFifoRequester(
             final long serialIntervalMillis,
@@ -56,9 +74,53 @@ final class OrpheFifoRequester<T> {
         running = true;
     }
 
+    /**
+     * 即時停止する。
+     *
+     * <p>要求済みで未受信のシリアル（carry-over）はもう回収されないため、
+     * 「気づかない欠損」を防ぐ目的で missing として通知してから破棄する。
+     * 回収を試みてから停止したい場合は{@link #beginDrain(long)}を使う。
+     */
     void stop() {
+        if (running) {
+            reportOutstandingAsMissing();
+        }
         running = false;
+        draining = false;
         reset();
+    }
+
+    /**
+     * 回収フェーズ（drain/catch-up）に入る。
+     *
+     * <p>次のcurrentState応答でFWの最新シリアルを固定ターゲットとして確定し、
+     * そこまでの未要求分と、要求済み未受信分（carry-over）の回収を続ける。
+     * 完了（または{@code drainTimeoutMillis}経過）で{@link Listener#onDrainCompleted}を
+     * 呼んで停止する。回収中も{@link #tick(long)}を呼び続けること。
+     *
+     * @return 回収フェーズに入った場合true。停止済み・回収無効（drainTimeoutMillis=0）の
+     * 場合は即時停止して false
+     */
+    boolean beginDrain(final long nowMillis) {
+        if (!running) {
+            return false;
+        }
+        if (config.drainTimeoutMillis <= 0L) {
+            stop();
+            return false;
+        }
+        if (draining) {
+            return true;
+        }
+        draining = true;
+        drainDeadlineMillis = nowMillis + config.drainTimeoutMillis;
+        drainTargetSerial = null;
+        drainRecoveredCount = 0;
+        return true;
+    }
+
+    boolean isDraining() {
+        return draining;
     }
 
     /**
@@ -68,9 +130,16 @@ final class OrpheFifoRequester<T> {
         if (!running) {
             return;
         }
+        if (draining && nowMillis >= drainDeadlineMillis) {
+            finishDrain();
+            return;
+        }
         if (activeRequest != null) {
             if (activeRequest.hasTimedOut(nowMillis)) {
                 finishActiveRequest(true);
+                if (!running) {
+                    return;
+                }
             } else {
                 return;
             }
@@ -116,7 +185,16 @@ final class OrpheFifoRequester<T> {
             return;
         }
 
-        final int current = normalizeSerialNumber(currentSerialNumber);
+        int current = normalizeSerialNumber(currentSerialNumber);
+        if (draining) {
+            if (drainTargetSerial == null) {
+                // 停止時点のFW最新シリアルを固定ターゲットとして確定する。
+                // 以降にFWが生成する分は追わない（追うと回収が終わらない）。
+                drainTargetSerial = current;
+            } else {
+                current = drainTargetSerial;
+            }
+        }
         final NewRange newRange = calculateNewRange(current, accumulatedCount);
         final int reservedRanges = newRange.count > 0 ? 1 : 0;
         final int maxCarryRanges = MAX_REQUEST_RANGES - reservedRanges;
@@ -138,6 +216,10 @@ final class OrpheFifoRequester<T> {
         }
         requests.addAll(carryRequests);
         if (requests.isEmpty()) {
+            if (draining) {
+                // ターゲットまで要求済みで、持ち越しも無い＝回収完了。
+                finishDrain();
+            }
             return;
         }
 
@@ -159,6 +241,9 @@ final class OrpheFifoRequester<T> {
             if (activeRequest.resolvedSerials.add(normalized)) {
                 activeRequest.markProgress(nowMillis);
                 carryOverSerials.remove(normalized);
+                if (draining) {
+                    drainRecoveredCount++;
+                }
                 listener.onValue(value);
                 completeRequestIfResolved();
             }
@@ -167,7 +252,11 @@ final class OrpheFifoRequester<T> {
 
         // タイムアウト後、次の要求を作る前に遅延パケットが届いた場合も回収する。
         if (carryOverSerials.remove(normalized)) {
+            if (draining) {
+                drainRecoveredCount++;
+            }
             listener.onValue(value);
+            maybeCompleteDrain();
         }
     }
 
@@ -297,12 +386,78 @@ final class OrpheFifoRequester<T> {
             carryOverSerials.clear();
             lastSerialNumber = null;
         }
+
+        maybeCompleteDrain();
+    }
+
+    /**
+     * 回収フェーズの完了判定。要求中でなく、持ち越しが無く、確定済みターゲットまで
+     * 要求し終えていれば完了する。
+     */
+    private void maybeCompleteDrain() {
+        if (!draining || !running || activeRequest != null) {
+            return;
+        }
+        if (!carryOverSerials.isEmpty()) {
+            return;
+        }
+        if (drainTargetSerial == null || lastSerialNumber == null) {
+            // ターゲット未確定・再同期直後は次のcurrentState応答で判定する。
+            return;
+        }
+        if (forwardSerialDistance(lastSerialNumber, drainTargetSerial) <= 0) {
+            finishDrain();
+        }
+    }
+
+    /** 回収フェーズを終了し、取り残しを missing として通知してから停止する。 */
+    private void finishDrain() {
+        final int unrecovered = reportOutstandingAsMissing();
+        final int recovered = drainRecoveredCount;
+        running = false;
+        draining = false;
+        reset();
+        listener.onDrainCompleted(recovered, unrecovered);
+    }
+
+    /**
+     * 停止時点で回収不能と確定した未受信シリアルを missing として通知する。
+     *
+     * <p>対象: 持ち越し（要求済み未受信）、実行中要求の未解決分、および回収フェーズで
+     * 確定したターゲットまでの未要求分（catch-upしきれなかった分）。通知した数を返す。
+     */
+    private int reportOutstandingAsMissing() {
+        final LinkedHashSet<Integer> unrecovered = new LinkedHashSet<>(carryOverSerials);
+        if (activeRequest != null) {
+            for (int serialNumber : activeRequest.expectedSerials) {
+                if (!activeRequest.resolvedSerials.contains(serialNumber)) {
+                    unrecovered.add(serialNumber);
+                }
+            }
+        }
+        if (draining && drainTargetSerial != null && lastSerialNumber != null) {
+            final int gap = forwardSerialDistance(lastSerialNumber, drainTargetSerial);
+            for (int i = 1; i <= gap; i++) {
+                final int serialNumber = normalizeSerialNumber(lastSerialNumber + i);
+                if (activeRequest != null && activeRequest.resolvedSerials.contains(serialNumber)) {
+                    // 実行中要求で受信済み（またはnoData通知済み）の分は二重報告しない。
+                    continue;
+                }
+                unrecovered.add(serialNumber);
+            }
+        }
+        for (int serialNumber : unrecovered) {
+            listener.onMissing(serialNumber);
+        }
+        return unrecovered.size();
     }
 
     private void reset() {
         lastSerialNumber = null;
         activeRequest = null;
         carryOverSerials.clear();
+        drainTargetSerial = null;
+        drainRecoveredCount = 0;
     }
 
     static int normalizeSerialNumber(final int serialNumber) {

--- a/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheInsole.java
+++ b/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheInsole.java
@@ -78,6 +78,12 @@ public class OrpheInsole {
     private final Set<String> mDebugScanLoggedAddresses = new HashSet<>();
     private boolean mRequestLoopStarted;
     private OrpheFifoRequester<OrpheInsoleValue[]> mFifoRequester;
+
+    /** FIFO回収フェーズ（drain）完了後に適用する保留中のセンサー設定。 */
+    private OrpheInsoleSensorConfig mPendingSensorConfig;
+
+    /** FIFO回収フェーズを要求済みかどうか。 */
+    private boolean mFifoDrainRequested;
     private OrpheFifoInitializer mFifoInitializer;
     private OrpheInsoleValueAccumulator mFifoValues =
             new OrpheInsoleValueAccumulator();
@@ -351,9 +357,35 @@ public class OrpheInsole {
     /**
      * センサー値取得設定を変更します。接続中の場合は次回接続時に反映されます。
      *
+     * <p>fifo受信中に呼ばれた場合は、まず回収フェーズ（drain/catch-up）でFWバッファの
+     * 取り残しを回収してから新しい設定を適用します（上限は
+     * {@link OrpheFifoConfig#drainTimeoutMillis}。0で従来どおり即時切替）。
+     * 回収できなかったシリアルは{@link OrpheInsoleCallback#sensorValueIsNotFound}で通知されます。
+     *
      * @param sensorConfig センサー値取得設定
      */
     public void setSensorConfig(@NonNull final OrpheInsoleSensorConfig sensorConfig) {
+        if (mRequestLoopStarted
+                && mSensorConfig.receiveMode == OrpheSensorReceiveMode.fifo
+                && mStatus == OrpheCoreStatus.connected
+                && mFifoRequester != null) {
+            mPendingSensorConfig = sensorConfig;
+            if (mFifoDrainRequested) {
+                // すでに回収中: 適用する設定だけ差し替えて完了を待つ。
+                return;
+            }
+            if (mFifoRequester.beginDrain(System.currentTimeMillis())) {
+                mFifoDrainRequested = true;
+                Log.d(TAG, "FIFO drain before sensor config change");
+                return;
+            }
+            // 回収無効（drainTimeoutMillis=0）または停止済み: 即時適用へ。
+            mPendingSensorConfig = null;
+        }
+        applySensorConfigNow(sensorConfig);
+    }
+
+    private void applySensorConfigNow(@NonNull final OrpheInsoleSensorConfig sensorConfig) {
         final OrpheSensorReceiveMode previousReceiveMode = mSensorConfig.receiveMode;
         resetSamplingRateGuard();
         stopRequestLoop();
@@ -806,13 +838,22 @@ public class OrpheInsole {
 
     private void stopRequestLoop() {
         mRequestLoopStarted = false;
+        mFifoDrainRequested = false;
         mHandler.removeCallbacks(mRequestLoopRunnable);
         mHandler.removeCallbacks(mFifoInitializationRunnable);
         if (mFifoInitializer != null) {
             mFifoInitializer.stop();
         }
         if (mFifoRequester != null) {
+            // 回収中に切断等で停止した場合も含め、未回収分は missing として通知される。
             mFifoRequester.stop();
+        }
+        // 回収完了を待たずに停止した場合、保留中の設定は即時適用する
+        // （切断時は次回接続時に反映される従来semanticsに一致させる）。
+        final OrpheInsoleSensorConfig pending = mPendingSensorConfig;
+        if (pending != null) {
+            mPendingSensorConfig = null;
+            mHandler.post(() -> applySensorConfigNow(pending));
         }
     }
 
@@ -825,6 +866,10 @@ public class OrpheInsole {
         }
         final long nowMillis = System.currentTimeMillis();
         mFifoRequester.tick(nowMillis);
+        // tick中に回収フェーズが完了して設定が切り替わった場合はループを再開しない。
+        if (!mRequestLoopStarted) {
+            return;
+        }
         mHandler.postDelayed(
                 mRequestLoopRunnable,
                 mFifoRequester.nextTickDelayMillis(
@@ -902,6 +947,18 @@ public class OrpheInsole {
                     @Override
                     public void onMissing(int serialNumber) {
                         mOrpheCallback.sensorValueIsNotFound(serialNumber);
+                    }
+
+                    @Override
+                    public void onDrainCompleted(int recoveredCount, int unrecoveredCount) {
+                        Log.d(TAG, "FIFO drain completed: recovered=" + recoveredCount
+                                + " unrecovered=" + unrecoveredCount);
+                        mFifoDrainRequested = false;
+                        final OrpheInsoleSensorConfig pending = mPendingSensorConfig;
+                        mPendingSensorConfig = null;
+                        if (pending != null) {
+                            applySensorConfigNow(pending);
+                        }
                     }
                 }
         );

--- a/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheInsoleValue.java
+++ b/orphecoresdk/src/main/java/io/orphe/orphecoresdk/OrpheInsoleValue.java
@@ -21,6 +21,20 @@ public class OrpheInsoleValue {
     static final int PACKET_LENGTH_200_HZ = 104;
     static final int PACKET_LENGTH_100_HZ = 72;
 
+    /**
+     * 実機IMUの実測出力データレート[Hz]。
+     *
+     * <p>名目は200Hzだが、実機のパケット到来間隔を2台×約1500パケットで実測すると
+     * 208.98Hz / 208.13Hz となり、LSM6DSOX の標準ODR 208Hz（約4.808ms/frame）に一致する。
+     * 5ms固定でパケット内のフレーム時刻を合成すると、パケット内だけが約4%引き伸ばされ、
+     * パケット境界で連続サンプルの時刻差が0や負になりうる（サンプル毎のdtで積分する処理が
+     * 系統的にずれる）。JS SDK（ORPHE-INSOLE.js v1.3.1 の {@code IMU_ODR_HZ}）と同じ根拠・同じ値。
+     */
+    public static final double IMU_ODR_HZ = 208.0;
+
+    /** 1フレームの間隔[ns]（= 1e9 / {@link #IMU_ODR_HZ} ≒ 4.808ms）。 */
+    static final long FRAME_INTERVAL_NANOS = Math.round(1_000_000_000.0 / IMU_ODR_HZ);
+
     /// 圧力係数のデフォルト値
     private static final double DEFAULT_COEFFICIENT1 = 2.77942;
     private static final double DEFAULT_COEFFICIENT2 = 0.00235;
@@ -333,7 +347,8 @@ public class OrpheInsoleValue {
                 for (int outputIndex = 0; outputIndex < samplePositions.length; outputIndex++) {
                     final int s = samplePositions[outputIndex];
                     index = s * 24 + 8;
-                    final long duration = (3 - s) * 5_000_000L;
+                    // フレーム間隔は名目5msではなく実測ODR（208Hz≒4.808ms）に合わせる。
+                    final long duration = (3 - s) * FRAME_INTERVAL_NANOS;
                     final LocalDateTime timestamp = baseTimestamp.plusNanos(duration);
                     // request / fifoの受信処理で、復号後に時系列姿勢を計算する。
                     final double quatW = 0;
@@ -402,7 +417,8 @@ public class OrpheInsoleValue {
                 );
                 for (int s = 1; s >= 0; s--) {
                     index = s * 32 + 8;
-                    final long duration = (1 - s) * 10_000_000L;
+                    // 100Hzモードは208Hzストリームの1/2間引き＝2フレーム間隔（名目10msではなく約9.615ms）。
+                    final long duration = (1 - s) * 2L * FRAME_INTERVAL_NANOS;
                     final LocalDateTime timestamp = baseTimestamp.plusNanos(duration);
                     // realtime 100Hzではデバイス算出のクオータニオンを使用する。
                     final double quatW = parseInt(bytes, index) / 16384.0;

--- a/orphecoresdk/src/test/java/io/orphe/orphecoresdk/ExampleUnitTest.java
+++ b/orphecoresdk/src/test/java/io/orphe/orphecoresdk/ExampleUnitTest.java
@@ -40,7 +40,8 @@ public class ExampleUnitTest {
         assertEquals(0x1234, values[0].serialNumber);
         assertEquals(3, values[0].dataPosition);
         assertEquals(0, values[3].dataPosition);
-        assertEquals(15, values[3].startTime - values[0].startTime);
+        // 3フレーム × 4.808ms（実測ODR 208Hz） = 14.42ms → epochミリ秒への切り捨てで14
+        assertEquals(14, values[3].startTime - values[0].startTime);
         for (OrpheInsoleValue value : values) {
             assertEquals(0.0, value.quatW, 0.0);
             assertEquals(0.0, value.quatX, 0.0);
@@ -70,7 +71,8 @@ public class ExampleUnitTest {
         assertEquals(2, values.length);
         assertEquals(1, values[0].dataPosition);
         assertEquals(0, values[1].dataPosition);
-        assertEquals(10, values[1].startTime - values[0].startTime);
+        // 2フレーム × 4.808ms = 9.62ms → epochミリ秒への切り捨てで9
+        assertEquals(9, values[1].startTime - values[0].startTime);
         assertEquals(3000.0 * OrpheGyroRange.range2000.sensitivity,
                 values[0].gyroX, 1.0E-9);
         assertEquals(1000.0 * OrpheGyroRange.range2000.sensitivity,
@@ -93,7 +95,8 @@ public class ExampleUnitTest {
         assertEquals(4, values.length);
         assertEquals(3, values[0].dataPosition);
         assertEquals(0, values[3].dataPosition);
-        assertEquals(15, values[3].startTime - values[0].startTime);
+        // 3フレーム × 4.808ms = 14.42ms → 14
+        assertEquals(14, values[3].startTime - values[0].startTime);
     }
 
     @Test
@@ -129,7 +132,8 @@ public class ExampleUnitTest {
         assertEquals(0x1234, values[0].serialNumber);
         assertEquals(1, values[0].dataPosition);
         assertEquals(0, values[1].dataPosition);
-        assertEquals(10, values[1].startTime - values[0].startTime);
+        // 100Hzは208Hzストリームの1/2間引き: 2フレーム × 4.808ms = 9.62ms → 9
+        assertEquals(9, values[1].startTime - values[0].startTime);
         for (OrpheInsoleValue value : values) {
             assertEquals(1.0, value.quatW, 1.0E-9);
             assertEquals(255.0 / 16384.0, value.quatX, 1.0E-9);

--- a/orphecoresdk/src/test/java/io/orphe/orphecoresdk/OrpheFifoRequesterTest.java
+++ b/orphecoresdk/src/test/java/io/orphe/orphecoresdk/OrpheFifoRequesterTest.java
@@ -247,6 +247,144 @@ public class OrpheFifoRequesterTest {
         assertEquals(Arrays.asList("200:1"), recorder.requests.get(1));
     }
 
+    @Test
+    public void stopReportsOutstandingCarryOverAsMissing() {
+        Recorder recorder = new Recorder();
+        OrpheFifoRequester<Integer> requester = requester(recorder);
+        requester.start();
+        requester.onCurrentState(3, 3, 0L);
+        requester.onValue(1, 1, 10L);
+        requester.tick(300L); // 総タイムアウト(200ms)超過 → 2,3がcarry-overへ
+
+        requester.stop();
+
+        assertEquals(Arrays.asList(2, 3), recorder.missing);
+        assertFalse(requester.isRunning());
+        assertEquals(0, recorder.drainCompletions);
+    }
+
+    @Test
+    public void drainCompletesImmediatelyWhenNothingOutstanding() {
+        Recorder recorder = new Recorder();
+        OrpheFifoRequester<Integer> requester = requester(recorder);
+        requester.start();
+        requester.onCurrentState(3, 3, 0L);
+        requester.onValue(1, 1, 10L);
+        requester.onValue(2, 2, 11L);
+        requester.onValue(3, 3, 12L);
+
+        assertTrue(requester.beginDrain(100L));
+        assertTrue(requester.isDraining());
+        requester.tick(100L);
+        requester.onCurrentState(3, 0, 110L); // FWに新規なし・持ち越しなし
+
+        assertEquals(1, recorder.drainCompletions);
+        assertEquals(0, recorder.lastDrainRecovered);
+        assertEquals(0, recorder.lastDrainUnrecovered);
+        assertTrue(recorder.missing.isEmpty());
+        assertFalse(requester.isRunning());
+    }
+
+    @Test
+    public void drainRecoversCarryOverAndForwardBacklogBeforeCompleting() {
+        Recorder recorder = new Recorder();
+        OrpheFifoRequester<Integer> requester = requester(recorder);
+        requester.start();
+        requester.onCurrentState(3, 3, 0L);
+        requester.onValue(1, 1, 10L);
+        requester.onValue(3, 3, 12L);
+        requester.tick(300L); // 2がcarry-overへ
+
+        assertTrue(requester.beginDrain(400L));
+        requester.tick(400L);
+        // 停止時点でFWは5まで生成済み → catch-up(4..5) + carry-over(2)を要求する
+        requester.onCurrentState(5, 0, 410L);
+        requester.onValue(4, 4, 420L);
+        requester.onValue(2, 2, 421L);
+        requester.onValue(5, 5, 422L);
+
+        assertEquals(1, recorder.drainCompletions);
+        assertEquals(3, recorder.lastDrainRecovered);
+        assertEquals(0, recorder.lastDrainUnrecovered);
+        assertTrue(recorder.missing.isEmpty());
+        assertEquals(Arrays.asList(1, 3, 4, 2, 5), recorder.values);
+        assertFalse(requester.isRunning());
+    }
+
+    @Test
+    public void drainFreezesTargetWhileFirmwareKeepsProducing() {
+        Recorder recorder = new Recorder();
+        OrpheFifoRequester<Integer> requester = requester(recorder);
+        requester.start();
+        requester.onCurrentState(3, 3, 0L);
+        requester.onValue(1, 1, 10L);
+        requester.onValue(2, 2, 11L);
+        requester.onValue(3, 3, 12L);
+
+        assertTrue(requester.beginDrain(1000L));
+        requester.tick(1000L);
+        requester.onCurrentState(5, 0, 1010L); // ターゲットを5に固定
+        requester.tick(1300L); // 応答なし → 総タイムアウト → 4,5がcarry-overへ → 再問い合わせ
+        requester.onCurrentState(8, 0, 1310L); // FWは8まで進んだが、5より先は要求しない
+        requester.onValue(4, 4, 1320L);
+        requester.onValue(5, 5, 1321L);
+
+        assertEquals(1, recorder.drainCompletions);
+        for (List<String> ranges : recorder.requests) {
+            for (String range : ranges) {
+                final String[] parts = range.split(":");
+                final int start = Integer.parseInt(parts[0]);
+                final int length = Integer.parseInt(parts[1]);
+                assertTrue("serial beyond frozen target was requested: " + range,
+                        start + length - 1 <= 5);
+            }
+        }
+        assertFalse(requester.isRunning());
+    }
+
+    @Test
+    public void drainDeadlineReportsUnrecoveredAndCompletes() {
+        Recorder recorder = new Recorder();
+        OrpheFifoRequester<Integer> requester = requester(recorder);
+        requester.start();
+        requester.onCurrentState(3, 3, 0L);
+        requester.onValue(1, 1, 10L);
+        requester.onValue(2, 2, 11L);
+        requester.onValue(3, 3, 12L);
+
+        assertTrue(requester.beginDrain(1000L));
+        requester.tick(1000L);
+        requester.onCurrentState(6, 0, 1010L); // 4..6をcatch-up要求
+        requester.onValue(4, 4, 1020L);        // 4だけ回収できた
+        requester.tick(4000L);                 // drainTimeoutMillis(3000)経過
+
+        assertEquals(1, recorder.drainCompletions);
+        assertEquals(1, recorder.lastDrainRecovered);
+        assertEquals(2, recorder.lastDrainUnrecovered);
+        assertEquals(Arrays.asList(5, 6), recorder.missing);
+        assertFalse(requester.isRunning());
+    }
+
+    @Test
+    public void drainDisabledFallsBackToImmediateStop() {
+        Recorder recorder = new Recorder();
+        OrpheFifoRequester<Integer> requester = new OrpheFifoRequester<>(
+                20L,
+                new OrpheFifoConfig(10, 100L, 200L, 10, 1500, 0L),
+                recorder
+        );
+        requester.start();
+        requester.onCurrentState(3, 3, 0L);
+        requester.onValue(1, 1, 10L);
+        requester.tick(300L); // 2,3がcarry-overへ
+
+        assertFalse(requester.beginDrain(400L));
+
+        assertEquals(Arrays.asList(2, 3), recorder.missing);
+        assertEquals(0, recorder.drainCompletions);
+        assertFalse(requester.isRunning());
+    }
+
     private OrpheFifoRequester<Integer> requester(Recorder recorder) {
         return new OrpheFifoRequester<>(
                 20L,
@@ -258,6 +396,9 @@ public class OrpheFifoRequesterTest {
     private static final class Recorder
             implements OrpheFifoRequester.Listener<Integer> {
         int currentStateRequests;
+        int drainCompletions;
+        int lastDrainRecovered = -1;
+        int lastDrainUnrecovered = -1;
         final List<List<String>> requests = new ArrayList<>();
         final List<Integer> requestedSerialCounts = new ArrayList<>();
         final List<Integer> values = new ArrayList<>();
@@ -288,6 +429,13 @@ public class OrpheFifoRequesterTest {
         @Override
         public void onMissing(int serialNumber) {
             missing.add(serialNumber);
+        }
+
+        @Override
+        public void onDrainCompleted(int recoveredCount, int unrecoveredCount) {
+            drainCompletions++;
+            lastDrainRecovered = recoveredCount;
+            lastDrainUnrecovered = unrecoveredCount;
         }
     }
 }


### PR DESCRIPTION
## 概要

INSOLE のデータ品質に関わる2件の修正です。どちらも JS SDK（ORPHE-INSOLE.js）で先に発見・修正された問題の Android 版で、根拠と修正方針は Orphe-OSS/ORPHE-INSOLE.js#62 と同一です。

## 1. パケット内フレーム時刻を実測ODR 208Hz に合わせる（`3bd0bdb`）

実機IMUの実測ODRは名目の200Hzではなく **208Hz**（LSM6DSOX標準ODR、約4.808ms/frame）です（2台×約1500パケットのパケット到来間隔の実測: 208.98Hz / 208.13Hz）。

従来はパケット内のフレーム時刻を 5ms（100Hz経路は10ms）固定で合成していたため、パケット内だけが約4%引き伸ばされ、**パケット境界で連続サンプルの時刻差が0や負になりえます**。サンプル毎のdtで角速度等を積分する処理（PDR等）が系統的にずれます。

- `OrpheInsoleValue.IMU_ODR_HZ`（208）と `FRAME_INTERVAL_NANOS` を追加
- 200Hz経路（header 54/55）: `(3-s)*5ms` → `(3-s)*FRAME_INTERVAL_NANOS`
- 100Hz経路（header 56）: `(1-s)*10ms` → `(1-s)*2*FRAME_INTERVAL_NANOS`（208Hzの1/2間引きとみなす）

**要確認**: 100Hz経路を「208Hzの1/2間引き＝約9.615ms間隔」とみなしています。FWの100Hzモードが独立タイマー駆動（真の10ms）の場合はこの仮定が誤りなので、FW実装をご存知の方の確認をお願いします。

## 2. FIFO停止時の回収フェーズ（drain/catch-up）と欠損の可視化（`54a1b44`）

従来の `OrpheFifoRequester.stop()` には2つの問題がありました:

1. 再要求キュー（carry-over）を**無通知で破棄**する
2. FWが生成済みでまだ要求していない**前方バックログを回収しない**（欠損にも計上されない）

結果として「欠損通知ゼロ」のまま収録末尾が数秒欠ける**偽のロスレス**が発生しえます（2台同時収録の実測で、遅れた側が要求スパンの86〜89%しか記録されない例を確認。JS SDK側の実測値）。

変更点:
- `OrpheFifoRequester.beginDrain()`: 最初のcurrentState応答でFW最新シリアルを**固定ターゲット**として確定し、catch-up＋carry-over の回収を続ける。完了/期限で `onDrainCompleted` → 停止
- `stop()`（即時停止・切断・close）: 未受信シリアルを `sensorValueIsNotFound` で通知してから破棄（CORE `Orphe` も同じListener経由で同様）
- `OrpheFifoConfig.drainTimeoutMillis`（既定3000ms、0で従来動作）。既存コンストラクタは既定値に委譲するため後方互換
- `OrpheInsole.setSensorConfig`: fifo受信中の設定変更は回収完了後に適用（保留設定は差し替え可。切断時は即時適用にフォールバック）
- 取りこぼしが無い正常系では回収は1往復で完了（実質遅延なし）

## テスト

- `OrpheFifoRequesterTest` に回収フェーズの単体テスト6件を追加（即時stop欠損通知 / 未回収なし即完了 / carry-over+catch-up回収 / ターゲット固定 / 期限切れ通知 / drain無効）
- `ExampleUnitTest` の時刻スパン期待値を更新（15→14ms、10→9ms）
- ⚠️ **手元にJDK/Android SDKが無いため、ローカルでのコンパイル・テスト実行は未実施です。** レビュー時に `./gradlew :orphecoresdk:testDebugUnitTest` の実行をお願いします

## 実機での検証観点

1. FIFO収録→停止（設定切替）で、末尾まで欠けずに記録されること（シリアル連続性の確認）
2. 意図的にリンク品質を落とした状態で停止したとき、`sensorValueIsNotFound` が取り残し分を通知すること
3. 停止から新設定適用までの遅延が正常系でほぼゼロであること

## スコープ外（別途提案）

収録**中**のリングバッファ上書き（追従遅れ、`calculateNewRange` のskip）は従来どおり無通知です。通知チャネルが per-serial callback しかなく、上書きは数千シリアル単位になりうるため、集約コールバック（例: `onSerialsSkipped(int count)`）の追加を別PRで提案します。
